### PR TITLE
Fixed the faulty test case.

### DIFF
--- a/Lecture1_Asgn2_Editorial_Solution/src/main/java/Rectangle.java
+++ b/Lecture1_Asgn2_Editorial_Solution/src/main/java/Rectangle.java
@@ -6,7 +6,7 @@ public class Rectangle {
     Point getBottomRight(){
         Point p = new Point();
         p.x = topLeft.x + width;
-        p.y = topLeft.y + height;
+        p.y = topLeft.y - height;
         return p;
     }
 

--- a/Lecture1_Asgn2_Editorial_Solution/src/test/java/RectangleTest.java
+++ b/Lecture1_Asgn2_Editorial_Solution/src/test/java/RectangleTest.java
@@ -191,7 +191,7 @@ class RectangleTest {
         Point bottomRight = (Point) getBottomRightMethod.invoke(rectangle);
 
         assertEquals(8, bottomRight.x);
-        assertEquals(10, bottomRight.y);
+        assertEquals(-2, bottomRight.y);
     }
 
 


### PR DESCRIPTION
Issue Description:

When calculating the position of the bottom right corner for a rectangle, with top left point as (3,4), height as 6 and width as 5, I'm getting a different result than expected.

Expected Result:

The expected result for the position of the bottom right corner of the rectangle is (8, -2).